### PR TITLE
Add tomli as a pre-requisite in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This program aims to do:
 
 ## Installation
 Pre-requisites
+* [tomli](https://github.com/hukkin/tomli)
 * [PySCF](https://github.com/pyscf/pyscf)
 * MOKIT (optional, no need to fully compile, only `autopair` is needed)
 * [ExSCF](https://github.com/hebrewsnabla/ExSCF) (optional, for SUHF)


### PR DESCRIPTION
In some (min-)conda environments where [tomli](https://github.com/hukkin/tomli) is not installed by default, the user needs to manually install it first to properly use [pyAutoMR](https://github.com/jeanwsr/pyAutoMR).

The necessity of this dependency can also be verified in the [source code](https://github.com/jeanwsr/pyAutoMR/blob/f57f0be0c400732a55d34946ffce2ca6821dd78c/automr/util.py#L3) as of 0.3.0.